### PR TITLE
Fix "breaks on dragonfly 1.1.1"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 cache: bundler
 script: 'bundle exec rake'
 rvm:
-  - 2.2.4
+  - 2.2.5
 services:
   - mongodb
 

--- a/lib/dragonfly/mongoid_data_store.rb
+++ b/lib/dragonfly/mongoid_data_store.rb
@@ -6,18 +6,11 @@ Dragonfly::App.register_datastore(:mongoid){ Dragonfly::MongoidDataStore }
 
 module Dragonfly
   class MongoidDataStore
-
     class DataNotFound < StandardError; end
-
-    # ---------------------------------------------------------------------
 
     include Serializer
 
-    # ---------------------------------------------------------------------
-
     OBJECT_ID = BSON::ObjectId
-
-    # =====================================================================
 
     def write temp_object, opts={}
       content_type = opts[:content_type] || opts[:mime_type] || 'application/octet-stream'
@@ -29,8 +22,6 @@ module Dragonfly
         grid_file.id.to_s
       end
     end
-
-    # ---------------------------------------------------------------------
 
     def read uid
       grid_file = Mongoid::GridFS.get(uid)
@@ -45,13 +36,14 @@ module Dragonfly
       raise DataNotFound, "#{e} - #{uid}"
     end
 
-    # ---------------------------------------------------------------------
-
     def destroy uid
       Mongoid::GridFs.delete(uid)
     end
 
-    # ---------------------------------------------------------------------
+    private # =============================================================
 
+    def marshal_b64_encode object
+      Dragonfly::Serializer.b64_encode(Marshal.dump(object))
+    end
   end
 end

--- a/test/dragonfly/mongoid_data_store_test.rb
+++ b/test/dragonfly/mongoid_data_store_test.rb
@@ -3,17 +3,12 @@ require 'dragonfly/mongoid_data_store'
 require 'dragonfly/serializer'
 
 describe Dragonfly::MongoidDataStore do
-
   include Dragonfly::Serializer
-
-  # ---------------------------------------------------------------------
 
   let(:app) { Dragonfly.app }
   let(:content) { Dragonfly::Content.new(app, "Foo Bar!") }
   let(:data_store) { Dragonfly::MongoidDataStore.new }
   let(:meta) { { my_meta: 'my meta' } }
-
-  # ---------------------------------------------------------------------
 
   describe '#write' do
     it "stores the data in the database" do
@@ -41,11 +36,9 @@ describe Dragonfly::MongoidDataStore do
     end
   end
 
-  # ---------------------------------------------------------------------
-
   describe '#read' do
     before do
-      stored_content = Mongoid::GridFS.put(content.file, content_type: 'text/plain', meta: marshal_b64_encode(meta))
+      stored_content = Mongoid::GridFS.put(content.file, content_type: 'text/plain', meta: b64_encode(Marshal.dump(meta)))
       @result = data_store.read(stored_content.id)
     end
 
@@ -62,8 +55,6 @@ describe Dragonfly::MongoidDataStore do
     end
   end
 
-  # ---------------------------------------------------------------------
-
   describe '#destroy' do
     before do
       @stored_content = Mongoid::GridFS.put(content.file)
@@ -75,7 +66,4 @@ describe Dragonfly::MongoidDataStore do
       Mongoid::GridFS.find(_id: @stored_content.id).must_be_nil
     end
   end
-
-  # ---------------------------------------------------------------------
-
 end


### PR DESCRIPTION
Fixes issue #1

Since they removed the `marshal_b64_encode` method, I simply add it again as a private method of the `MongoidDataStore` class. As I see it is the best/simplest solution? Also corrected the test.